### PR TITLE
Add lvm2 to listed prerequisites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,7 @@ Build Requirements
 * `kpartx`
 * `mkfs.vfat`
 * `mkfs.ext4`
+* `lvm2`
 * raspbain archive key installed
 
 On Debian and derivatives::


### PR DESCRIPTION
Just ran through my first attempt to build from scratch and the only thing missing from my Debian install that wasn't listed was lvm2
